### PR TITLE
fix(ncurses): do not called endwin() twice

### DIFF
--- a/nccm/nccm
+++ b/nccm/nccm
@@ -1695,7 +1695,6 @@ class Connections:
         CommandLine += (self.SshProgram, )
 
         if '<user>@' in SelectedEntry.UserAddr:
-            RestoreTerminal(self.stdscr)
             PromptedUser = PromptForUserLogin("Enter username to use for <username>@server : ")
             #CommandLine += ('{}@{}'.format(PromptedUser, SelectedEntry.Address), )
             CommandLine += (SelectedEntry.UserAddr.replace('<user>', PromptedUser), )
@@ -1781,7 +1780,6 @@ class Connections:
                 .format(NewScreenHeight, NewScreenWidth))
 
         if NewScreenHeight != GlobalConfig.ScreenHeight or NewScreenWidth != GlobalConfig.ScreenWidth:
-            RestoreTerminal(self.stdscr)
             LogWrite.warning( { 'tee': '\nnccm: Resizing the window during menu display is not supported.\nYou may resize the window during or after connection initiation.\nIf nccm returns after you disconnect - it will use the new window size.\n' } )
             sys.exit(1)
 
@@ -2133,16 +2131,6 @@ def PromptForUserLogin(PromptText):
     return Ans.rstrip()
 
 
-def RestoreTerminal(stdscr):
-    ''' Restore the terminal to a sane status '''
-
-    curses.curs_set(1)          # Restore blinking cursor
-    curses.echo()               # Restore terminal echo
-    stdscr.keypad(False)        # Return special keys to normal
-    curses.noraw()              # Return raw mode to normal
-    curses.endwin()             # End curses session
-
-
 def UpdateDisplay():
     ''' The window objects were added to GlobalConfig.DisplayObjects list,
         so here we need to use the Display method of those objects. '''
@@ -2199,7 +2187,6 @@ def SetupCurses(stdscr):
         # ^ Used for setting alerts such as 'LogTee'
 
     if not curses.has_colors(): # Color not supported
-        RestoreTerminal(stdscr)
         LogWrite.warning( { 'tee': '\nnccm: This program requires color support\n' } )
         return False
 
@@ -2208,13 +2195,11 @@ def SetupCurses(stdscr):
         .format(GlobalConfig.ScreenHeight, GlobalConfig.ScreenWidth))
 
     if GlobalConfig.ScreenWidth < 60 or GlobalConfig.ScreenHeight < 15:
-        RestoreTerminal(stdscr)
         LogWrite.warning( { 'tee': '\nnccm: Window must be at least 60x15. GlobalConfig.ScreenHeight == {} , GlobalConfig.ScreenWidth == {}\n'
             .format(GlobalConfig.ScreenHeight, GlobalConfig.ScreenWidth) } )
         return False
 
     if len(GlobalConfig.FilterTextArg) > GlobalConfig.ScreenWidth-32:
-        RestoreTerminal(stdscr)
         LogWrite.warning( { 'tee': '\nnccm: Filter text too long ({} chars). For your window size enter no more than {} chars\n'
             .format(len(GlobalConfig.FilterTextArg), GlobalConfig.ScreenWidth-32) } )
         return False
@@ -2362,8 +2347,6 @@ def MainCursesFunction(stdscr):
         LogWrite.debug('Clearing:  GlobalConfig.FilterTextArg')
         CommandInfo = ConnectionsList.GetCommandLine(
             ConnectionsList.SelectedEntryVal)
-        #RestoreTerminal(stdscr)
-            # ^ Moved into:  GetCommandLine  due to prompt admin for username.
         return CommandInfo
 
     LogWrite.debug('Active window is now: ActiveWindow == {}  (the user input textbox that is active right now)'
@@ -2631,7 +2614,6 @@ def MainCursesFunction(stdscr):
         UpdateDisplay()
         ActiveWindow.ActivateWindow()
 
-    RestoreTerminal(stdscr)
     return CommandInfo
 
 


### PR DESCRIPTION
This commit fixes a problem where `curses.endwin()` was called explicitly, but also implicitly by `curses.wrapper()`

Due to a recent patch in ncurses 20231111
https://invisible-island.net/ncurses/NEWS.html#index-t20231111
> modify endwin() to return an error if it is called again without an
  intervening screen update (report by Rajeev Pillai, NetBSD #57592).

This now raises an error instead of being silently ignored.

Closes https://github.com/flyingrhinonz/nccm/issues/22

Ping @flyingrhinonz @Mte90